### PR TITLE
Fix CryptoReader buffer alignment

### DIFF
--- a/crypto/src/decrypt.rs
+++ b/crypto/src/decrypt.rs
@@ -149,10 +149,12 @@ impl<R: std::io::Read, const BUFFER_SIZE: usize> CryptoReader<R, BUFFER_SIZE> {
             .map_err(|e| error!(Other, "AES Decryption error: {}", e))?;
         dbg_println!("Block decrypted: {}", result.len());
         increment_nonce(&mut self.nonce);
-        // Setup buffer
+        // Setup buffer - store decrypted bytes right-aligned in the buffer so that
+        // subsequent reads can assume the data starts at `BUFFER_SIZE - buffer_len`.
         self.buffer_len = self.enc_buffer_len - AES_AUTH_TAG_LEN;
-        self.buffer[..self.buffer_len].copy_from_slice(result.as_slice());
-        // Reset encrpyted buffer
+        let start = BUFFER_SIZE - self.buffer_len;
+        self.buffer[start..start + self.buffer_len].copy_from_slice(result.as_slice());
+        // Reset encrypted buffer
         self.enc_buffer = vec![0; BUFFER_SIZE + AES_AUTH_TAG_LEN];
         self.enc_buffer_len = 0;
         Ok(())
@@ -220,7 +222,9 @@ impl<R: std::io::Read, const BUFFER_SIZE: usize> std::io::Read for CryptoReader<
             self.decrypt_buffer()?;
 
             let to_copy = min!(target_len - total_read, BUFFER_SIZE, self.buffer_len);
-            buf[total_read..total_read + to_copy].copy_from_slice(&self.buffer[..to_copy]);
+            let buffer_start_idx = BUFFER_SIZE - self.buffer_len;
+            buf[total_read..total_read + to_copy]
+                .copy_from_slice(&self.buffer[buffer_start_idx..buffer_start_idx + to_copy]);
             self.buffer_len -= to_copy;
             total_read += to_copy;
         }

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -290,6 +290,40 @@ mod tests {
     }
 
     #[test]
+    fn test_partial_reads_less_than_one_block() {
+        let keys = get_keys();
+        let (private_key, public_key) = {
+            let private_key = keys.private_key.as_ref().unwrap();
+            let public_key = keys.public_key.as_ref().unwrap();
+            (private_key.clone(), public_key.clone())
+        };
+
+        let mut encrypted = Vec::new();
+
+        {
+            let mut writer =
+                CryptoWriter::<_, 16>::new(&mut encrypted, public_key).unwrap();
+            writer.write_all(b"Hello, World!").unwrap();
+        }
+
+        let mut reader =
+            CryptoReader::<_, 16>::new(encrypted.as_slice(), private_key).unwrap();
+
+        let mut buf = [0u8; 5];
+        let mut decrypted = Vec::new();
+
+        loop {
+            let read = reader.read(&mut buf).unwrap();
+            if read == 0 {
+                break;
+            }
+            decrypted.extend_from_slice(&buf[..read]);
+        }
+
+        assert_eq!(b"Hello, World!", decrypted.as_slice());
+    }
+
+    #[test]
     fn test_more_than_one_block() {
         test_message::<16, _>("Hello, World!".repeat(10)); // Message is more than one block
     }


### PR DESCRIPTION
## Summary
- align decrypted buffer data to the end so partial reads return correct bytes
- adjust read logic to use aligned buffer start
- add regression test for partial reads that previously failed

## Testing
- `cargo test -q`

------
https://chatgpt.com/codex/tasks/task_e_6893242f692c8324bab3bd385f687d7b