### PR TITLE
feat: add git hooks for cargo checks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -12,7 +12,7 @@ cargo check
 
 # Run cargo clippy
 # -D warnings: treat warnings as errors
-# -- -D warnings ensures the code is clippy-clean
+# -D warnings passed to clippy treats warnings as errors
 # assuming this is not a release build; otherwise we could add appropriate flags
 # It is recommended to have `clippy` available
 # If not installed: run `rustup component add clippy`

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -13,7 +13,6 @@ cargo check
 # Run cargo clippy
 # -D warnings: treat warnings as errors
 # -D warnings passed to clippy treats warnings as errors
-# assuming this is not a release build; otherwise we could add appropriate flags
 # It is recommended to have `clippy` available
 # If not installed: run `rustup component add clippy`
 echo "Running cargo clippy"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Git pre-commit hook to ensure code passes basic checks
+set -e
+
+# Ensure code is formatted
+echo "Running cargo fmt -- --check"
+cargo fmt --all -- --check
+
+# Run cargo check
+echo "Running cargo check"
+cargo check
+
+# Run cargo clippy
+# -D warnings: treat warnings as errors
+# -- -D warnings ensures the code is clippy-clean
+# assuming this is not a release build; otherwise we could add appropriate flags
+# It is recommended to have `clippy` available
+# If not installed: run `rustup component add clippy`
+echo "Running cargo clippy"
+cargo clippy -- -D warnings
+

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Git pre-push hook to run tests before pushing
+set -e
+
+echo "Running cargo test"
+cargo test
+

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
   - [Next Steps](#next-steps)
   - [Usage](#usage)
     - [Running Tests](#running-tests)
+    - [Git Hooks](#git-hooks)
     - [Key Management](#key-management)
     - [Buffer-Sized Operations](#buffer-sized-operations)
   - [Example](#example)
@@ -105,6 +106,23 @@ To run the tests, use the following command:
 ```bash
 cargo test
 ```
+
+### Git Hooks
+
+To automatically run checks before committing or pushing code, enable the Git
+hooks provided in this repository:
+
+```bash
+git config --local core.hooksPath .githooks
+```
+
+The following hooks are available:
+
+- **pre-commit**: formats the code and runs `cargo check` and `cargo clippy` to
+  ensure the code builds cleanly and without lints.
+- **pre-push**: runs the test suite via `cargo test` before allowing a push.
+
+These hooks help catch issues early and keep the codebase consistent.
 
 ### Key Management
 


### PR DESCRIPTION
## Summary
- add pre-commit hook to run cargo fmt, cargo check and cargo clippy
- add pre-push hook to run cargo test
- document how to enable git hooks

## Testing
- `cargo fmt --all -- --check`
- `cargo check`
- `cargo clippy`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689331012e888324aa33bcb6b8334ffc