### PR TITLE
feat: add pluggable asym crypto backends

### DIFF
--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -8,4 +8,6 @@ license = "MIT"
 [dependencies]
 aes-gcm = "0.10.3"
 rand = "0.8.5"
+p256 = { version = "0.13", features = ["ecdh"] }
 rsa = "0.9.6"
+

--- a/crypto/src/backend.rs
+++ b/crypto/src/backend.rs
@@ -1,0 +1,119 @@
+use rand::{CryptoRng, RngCore};
+
+use crate::error::{error, Result};
+
+/// Backend trait for asymmetric encryption operations.
+///
+/// Implementors of this trait are able to encrypt and/or decrypt
+/// the randomly generated AES key that protects the bulk of the data.
+///
+/// Only the relevant operation needs to be implemented for a given
+/// type. For example public keys implement [`encrypt`] while private
+/// keys implement [`decrypt`]. The other operation can keep the default
+/// implementation which simply returns an error.
+pub trait Backend {
+    /// Size, in bytes, of the encrypted representation of the AES key.
+    const ENCRYPTED_KEY_LEN: usize;
+
+    /// Encrypt the provided AES key.
+    fn encrypt<R: CryptoRng + RngCore>(&self, _rng: &mut R, _data: &[u8]) -> Result<Vec<u8>> {
+        Err(error!(Other, "encryption not supported for this key"))
+    }
+
+    /// Decrypt the provided AES key.
+    fn decrypt(&self, _data: &[u8]) -> Result<Vec<u8>> {
+        Err(error!(Other, "decryption not supported for this key"))
+    }
+}
+
+// ---------------------------------------------------------------------
+// RSA backend implementation
+// ---------------------------------------------------------------------
+
+use rsa::{Pkcs1v15Encrypt, RsaPrivateKey, RsaPublicKey};
+
+/// RSA keys encrypt the AES key into a 256‑byte blob (2048‑bit RSA).
+const RSA_ENC_LEN: usize = 256;
+
+impl Backend for RsaPublicKey {
+    const ENCRYPTED_KEY_LEN: usize = RSA_ENC_LEN;
+
+    fn encrypt<R: CryptoRng + RngCore>(&self, rng: &mut R, data: &[u8]) -> Result<Vec<u8>> {
+        self.encrypt(rng, Pkcs1v15Encrypt, data)
+            .map_err(|e| error!(Other, "RSA Encryption error: {}", e))
+    }
+}
+
+impl Backend for RsaPrivateKey {
+    const ENCRYPTED_KEY_LEN: usize = RSA_ENC_LEN;
+
+    fn decrypt(&self, data: &[u8]) -> Result<Vec<u8>> {
+        self.decrypt(Pkcs1v15Encrypt, data)
+            .map_err(|e| error!(Other, "RSA Decryption error: {}", e))
+    }
+}
+
+// ---------------------------------------------------------------------
+// Elliptic Curve backend implementation (P-256)
+// ---------------------------------------------------------------------
+
+use p256::{
+    ecdh::{EphemeralSecret, SharedSecret},
+    PublicKey as EcPublicKey, SecretKey as EcPrivateKey,
+};
+use p256::elliptic_curve::sec1::ToEncodedPoint;
+
+/// For the EC backend we send the ephemeral public key (65 bytes,
+/// uncompressed) concatenated with the XOR of the AES key and the
+/// derived shared secret (32 bytes).
+const EC_ENC_LEN: usize = 65 + 32;
+
+impl Backend for EcPublicKey {
+    const ENCRYPTED_KEY_LEN: usize = EC_ENC_LEN;
+
+    fn encrypt<R: CryptoRng + RngCore>(&self, rng: &mut R, data: &[u8]) -> Result<Vec<u8>> {
+        if data.len() != 32 {
+            Err(error!(InvalidInput, "AES key must be 32 bytes"))?;
+        }
+
+        let ephemeral = EphemeralSecret::random(rng);
+        let ephemeral_pub = EcPublicKey::from(&ephemeral);
+        let shared = ephemeral.diffie_hellman(self);
+        let shared_bytes = shared.raw_secret_bytes();
+
+        let mut out = Vec::with_capacity(Self::ENCRYPTED_KEY_LEN);
+        out.extend_from_slice(ephemeral_pub.to_encoded_point(false).as_bytes());
+
+        for (a, b) in data.iter().zip(shared_bytes.as_slice()) {
+            out.push(a ^ b);
+        }
+
+        Ok(out)
+    }
+}
+
+impl Backend for EcPrivateKey {
+    const ENCRYPTED_KEY_LEN: usize = EC_ENC_LEN;
+
+    fn decrypt(&self, data: &[u8]) -> Result<Vec<u8>> {
+        if data.len() != Self::ENCRYPTED_KEY_LEN {
+            Err(error!(InvalidInput, "invalid encrypted key length"))?;
+        }
+
+        let (ephemeral_pub_bytes, encrypted_key) = data.split_at(65);
+        let ephemeral_pub = EcPublicKey::from_sec1_bytes(ephemeral_pub_bytes)
+            .map_err(|e| error!(Other, "Invalid public key: {}", e))?;
+
+        let shared = SharedSecret::new(&ephemeral_pub, self)
+            .map_err(|e| error!(Other, "ECDH error: {}", e))?;
+        let shared_bytes = shared.raw_secret_bytes();
+
+        let mut key = Vec::with_capacity(32);
+        for (a, b) in encrypted_key.iter().zip(shared_bytes.as_slice()) {
+            key.push(a ^ b);
+        }
+
+        Ok(key)
+    }
+}
+

--- a/crypto/src/decrypt.rs
+++ b/crypto/src/decrypt.rs
@@ -1,6 +1,7 @@
 //! This module contains the `CryptoReader` struct that decrypts data read from an underlying reader.
 //!
-//! The data is decrypted using AES-256-GCM. The AES key is decrypted using the RSA private key.
+//! The data is decrypted using AES-256-GCM. The AES key is decrypted using the
+//! asymmetric backend selected by the caller.
 //!
 //! The data is read from the reader in the following format:
 //!
@@ -8,7 +9,7 @@
 //! +-----------------+   +-----------------+   +-----------------+   +-----------------+   
 //! |     AES Key     |   |    AES NONCE    |   |     AES Data    |   |     AES Data    |   
 //! +-----------------+   +-----------------+   +-----------------+   +-----------------+   
-//! |     RSA Enc     |   |                 |   |                 |   |                 |   ...
+//! |  BACKEND Enc    |   |                 |   |                 |   |                 |   ...
 //! +-----------------+   +-----------------+   +-----------------+   +-----------------+   
 //! |   AES KEY LEN   |   |  AES NONCE LEN  |   |   BUFFER_SIZE   |   |   BUFFER_SIZE   |  
 //! +-----------------+   +-----------------+   +-----------------+   +-----------------+
@@ -26,10 +27,10 @@
 use super::{
     dbg_println,
     error::{error, Result},
-    shared::{increment_nonce, Nonce, AES_AUTH_TAG_LEN, AES_KEY_LEN, AES_NONCE_LEN},
+    shared::{increment_nonce, Nonce, AES_AUTH_TAG_LEN, AES_NONCE_LEN},
 };
 use aes_gcm::{aead::Aead, Aes256Gcm, Key, KeyInit as _};
-use rsa::{Pkcs1v15Encrypt, RsaPrivateKey};
+use crate::backend::Backend;
 
 macro_rules! min {
     ($($args:expr),*) => {
@@ -46,14 +47,14 @@ macro_rules! min {
 /// A reader that decrypts data read from an underlying reader.
 ///
 /// The data is decrypted using AES-256-GCM.
-/// The AES key is decrypted using the RSA private key.
+/// The AES key is decrypted using the backend private key.
 ///
 /// The data is read from the reader in the following format:
 /// ```plaintext
 /// +-----------------+   +-----------------+   +-----------------+   +-----------------+   
 /// |     AES Key     |   |    AES NONCE    |   |     AES Data    |   |     AES Data    |   
 /// +-----------------+   +-----------------+   +-----------------+   +-----------------+   
-/// |     RSA Enc     |   |                 |   |                 |   |                 |   ...
+/// |  BACKEND Enc    |   |                 |   |                 |   |                 |   ...
 /// +-----------------+   +-----------------+   +-----------------+   +-----------------+   
 /// |   AES KEY LEN   |   |  AES NONCE LEN  |   |   BUFFER_SIZE   |   |   BUFFER_SIZE   |  
 /// +-----------------+   +-----------------+   +-----------------+   +-----------------+
@@ -77,13 +78,13 @@ impl<R: std::io::Read, const BUFFER_SIZE: usize> CryptoReader<R, BUFFER_SIZE> {
     ///
     /// # Arguments
     /// - `reader`: The reader from which encrypted data is read.
-    /// - `key`: The RSA private key to decrypt the AES key.
+    /// - `key`: The private key used by the backend to decrypt the AES key.
     ///
     /// # Returns
     /// A `CryptoReader` instance.
     ///
     /// # Errors
-    /// - `Invalid Rsa Key`: If the RSA key is invalid.
+    /// - `Invalid Key`: If the backend key is invalid.
     /// - `Io`: If an I/O error occurs. Details are provided in the error message.
     ///
     /// # Safety
@@ -99,22 +100,19 @@ impl<R: std::io::Read, const BUFFER_SIZE: usize> CryptoReader<R, BUFFER_SIZE> {
     /// +-----------------+   +-----------------+   +-----------------+   +-----------------+   
     /// |     AES Key     |   |    AES NONCE    |   |     AES Data    |   |     AES Data    |   
     /// +-----------------+   +-----------------+   +-----------------+   +-----------------+   
-    /// |     RSA Enc     |   |                 |   |                 |   |                 |   ...
+    /// |  BACKEND Enc    |   |                 |   |                 |   |                 |   ...
     /// +-----------------+   +-----------------+   +-----------------+   +-----------------+   
     /// |   AES KEY LEN   |   |  AES NONCE LEN  |   |   BUFFER_SIZE   |   |   BUFFER_SIZE   |  
     /// +-----------------+   +-----------------+   +-----------------+   +-----------------+
     /// ```
     ///
-    pub fn new(mut reader: R, key: RsaPrivateKey) -> Result<Self> {
+    pub fn new<B: Backend>(mut reader: R, key: B) -> Result<Self> {
         let cipher = {
-            let buffer = &mut [0; AES_KEY_LEN];
-            reader.read_exact(buffer)?;
+            let mut buffer = vec![0; B::ENCRYPTED_KEY_LEN];
+            reader.read_exact(&mut buffer)?;
 
             // Decrypt the AES key
-            let raw_aes_key = key
-                .decrypt(Pkcs1v15Encrypt, buffer)
-                .map_err(|e| error!(Other, "RSA Decryption error: {}", e))?;
-
+            let raw_aes_key = key.decrypt(&buffer)?;
             let aes_key = Key::<Aes256Gcm>::from_slice(&raw_aes_key);
             Aes256Gcm::new(aes_key)
         };

--- a/crypto/src/encrypt.rs
+++ b/crypto/src/encrypt.rs
@@ -1,13 +1,14 @@
 //! This module provides a writer that encrypts the data before writing it to the writer.
 //!
-//! The data is encrypted using AES-256-GCM. The AES key is encrypted using the RSA public key.
+//! The data is encrypted using AES-256-GCM. The AES key is encrypted using the
+//! asymmetric backend provided by the user.
 //!
 //! The data is written to the writer in the following format:
 //! ```plaintext
 //! +-----------------+   +-----------------+   +-----------------+   +-----------------+   
 //! |     AES Key     |   |    AES NONCE    |   |     AES Data    |   |     AES Data    |   
 //! +-----------------+   +-----------------+   +-----------------+   +-----------------+   
-//! |     RSA Enc     |   |                 |   |                 |   |                 |   ...
+//! |  BACKEND Enc    |   |                 |   |                 |   |                 |   ...
 //! +-----------------+   +-----------------+   +-----------------+   +-----------------+   
 //! |   AES KEY LEN   |   |  AES NONCE LEN  |   |   BUFFER_SIZE   |   |   BUFFER_SIZE   |  
 //! +-----------------+   +-----------------+   +-----------------+   +-----------------+
@@ -29,7 +30,7 @@ use super::{
 };
 use aes_gcm::{aead::Aead, AeadCore as _, Aes256Gcm, Key, KeyInit as _};
 use rand::{CryptoRng, RngCore};
-use rsa::{Pkcs1v15Encrypt, RsaPublicKey};
+use crate::backend::Backend;
 use std::io::Write as _;
 
 fn generate_aes_key<R: CryptoRng + RngCore>(rng: &mut R) -> Key<Aes256Gcm> {
@@ -39,14 +40,14 @@ fn generate_aes_key<R: CryptoRng + RngCore>(rng: &mut R) -> Key<Aes256Gcm> {
 /// A writer that encrypts the data before writing it to the writer.
 ///
 /// The data is encrypted using AES-256-GCM.
-/// The AES key is encrypted using the RSA public key.
+/// The AES key is encrypted using the backend public key.
 ///
 /// The data is written to the writer in the following format:
 /// ```plaintext
 /// +-----------------+   +-----------------+   +-----------------+   +-----------------+   
 /// |     AES Key     |   |    AES NONCE    |   |     AES Data    |   |     AES Data    |   
 /// +-----------------+   +-----------------+   +-----------------+   +-----------------+   
-/// |     RSA Enc     |   |                 |   |                 |   |                 |   ...
+/// |  BACKEND Enc    |   |                 |   |                 |   |                 |   ...
 /// +-----------------+   +-----------------+   +-----------------+   +-----------------+   
 /// |   AES KEY LEN   |   |  AES NONCE LEN  |   |   BUFFER_SIZE   |   |   BUFFER_SIZE   |  
 /// +-----------------+   +-----------------+   +-----------------+   +-----------------+
@@ -68,13 +69,13 @@ impl<W: std::io::Write, const BUFFER_SIZE: usize> CryptoWriter<W, BUFFER_SIZE> {
     ///
     /// # Arguments
     /// - `writer`: The writer to write the encrypted data.
-    /// - `key`: The RSA public key to encrypt the AES key.
+    /// - `key`: The public key used by the backend to encrypt the AES key.
     ///
     /// # Returns
     /// A `CryptoWriter` instance.
     ///
     /// # Errors
-    /// - `Invalid Rsa Key`: If the RSA key is invalid.
+    /// - `Invalid Key`: If the backend key is invalid.
     /// - `Io`: If an I/O error occurs. Details are provided in the error message.
     ///
     /// # Safety
@@ -90,13 +91,13 @@ impl<W: std::io::Write, const BUFFER_SIZE: usize> CryptoWriter<W, BUFFER_SIZE> {
     /// +-----------------+   +-----------------+   +-----------------+   +-----------------+   
     /// |     AES Key     |   |    AES NONCE    |   |     AES Data    |   |     AES Data    |   
     /// +-----------------+   +-----------------+   +-----------------+   +-----------------+   
-    /// |     RSA Enc     |   |                 |   |                 |   |                 |   ...
+    /// |  BACKEND Enc    |   |                 |   |                 |   |                 |   ...
     /// +-----------------+   +-----------------+   +-----------------+   +-----------------+   
     /// |   AES KEY LEN   |   |  AES NONCE LEN  |   |   BUFFER_SIZE   |   |   BUFFER_SIZE   |  
     /// +-----------------+   +-----------------+   +-----------------+   +-----------------+
     /// ```
     ///
-    pub fn new(writer: W, key: RsaPublicKey) -> Result<Self> {
+    pub fn new<B: Backend>(writer: W, key: B) -> Result<Self> {
         // TODO: memlock secrets in memory
         let mut rng = setup_rng();
         Self::new_with_rng(writer, key, &mut rng)
@@ -107,7 +108,7 @@ impl<W: std::io::Write, const BUFFER_SIZE: usize> CryptoWriter<W, BUFFER_SIZE> {
     ///
     /// # Arguments
     /// - `writer`: The writer to write the encrypted data.
-    /// - `key`: The RSA public key to encrypt the AES key.
+    /// - `key`: The backend public key to encrypt the AES key.
     /// - `rng`: The random number generator.
     ///
     /// # Returns
@@ -117,9 +118,9 @@ impl<W: std::io::Write, const BUFFER_SIZE: usize> CryptoWriter<W, BUFFER_SIZE> {
     /// The random number generator must be cryptographically secure. And should implement the
     /// `CryptoRng` and `RngCore` traits. (From the `rand` crate)
     ///
-    pub fn new_with_rng<R: CryptoRng + RngCore>(
+    pub fn new_with_rng<R: CryptoRng + RngCore, B: Backend>(
         mut writer: W,
-        key: RsaPublicKey,
+        key: B,
         mut rng: R,
     ) -> Result<Self> {
         let aes_key = generate_aes_key(&mut rng);
@@ -127,9 +128,7 @@ impl<W: std::io::Write, const BUFFER_SIZE: usize> CryptoWriter<W, BUFFER_SIZE> {
 
         {
             let raw_aes_key = aes_key.as_slice();
-            let data = key
-                .encrypt(&mut rng, Pkcs1v15Encrypt, raw_aes_key)
-                .map_err(|e| error!(Other, "RSA Encryption error: {}", e))?;
+            let data = key.encrypt(&mut rng, raw_aes_key)?;
 
             if writer.write(&data)? != data.len() {
                 Err(error!(Other, "Failed to write the encrypted AES key"))?;

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -110,11 +110,13 @@
 mod decrypt;
 mod encrypt;
 mod error;
+mod backend;
 mod key;
 mod shared;
 
 pub use decrypt::CryptoReader;
 pub use encrypt::CryptoWriter;
+pub use backend::Backend;
 pub use error::Result; // Alias to std::io::Result
 pub use key::RsaKeys;
 
@@ -374,5 +376,29 @@ mod tests {
         handle.join().expect("failed to join thread");
 
         assert_eq!(data, decrypted.as_slice());
+    }
+
+    #[test]
+    fn ec_backend_roundtrip() {
+        use p256::{SecretKey, PublicKey};
+        let mut encrypted = Vec::new();
+        let mut rng = rand::thread_rng();
+        let secret = SecretKey::random(&mut rng);
+        let public = PublicKey::from(&secret);
+
+        {
+            let mut writer =
+                CryptoWriter::<_, 16>::new(&mut encrypted, public.clone()).expect("writer");
+            writer.write_all(b"ec message").expect("write");
+        }
+
+        let mut decrypted = Vec::new();
+        {
+            let mut reader =
+                CryptoReader::<_, 16>::new(encrypted.as_slice(), secret).expect("reader");
+            reader.read_to_end(&mut decrypted).expect("read");
+        }
+
+        assert_eq!(b"ec message", decrypted.as_slice());
     }
 }

--- a/crypto/src/shared.rs
+++ b/crypto/src/shared.rs
@@ -9,8 +9,6 @@ use rand::rngs::ThreadRng;
 
 // Enforce 2048 bits key length. (Temporary solution)
 pub(crate) const RSA_KEY_LEN: usize = 2048;
-// RSA 2048 bits creates a 256 bytes encrypted data chunk.
-pub(crate) const AES_KEY_LEN: usize = 256;
 // 96 bits nonce for AES-GCM.
 pub(crate) const AES_NONCE_LEN: usize = 12;
 // 128 bits authentication tag for AES-GCM.


### PR DESCRIPTION
## Summary
- add `Backend` trait with RSA and P-256 implementations
- make `CryptoWriter`/`CryptoReader` generic over backend
- test elliptic-curve backend roundtrip

## Testing
- `cargo test` *(fails: failed to download from https://index.crates.io/config.json)*

------
https://chatgpt.com/codex/tasks/task_e_689339b027f08324953d1f08aa1ba27e